### PR TITLE
Remove Sync marker in Tx, Rx, AsyncTx, AsyncRx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
+## [2.0.4]
+
+### Changed
+
+- Remove Sync marker in Tx, Rx, AsyncTx, AsyncRx to prevent misuse with Arc
+
+
 ## [2.0.3] - 2025-07-07
 
 ### Changed
@@ -25,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AsyncRx should not have Clone.
 
-- Protect against mis-use of spsc/mpsc when user should use mpmc (avoiding deadlocks)
+- Protect against misuse of spsc/mpsc when user should use mpmc (avoiding deadlocks)
 
 ## [2.0.2] - 2025-07-05
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -9,7 +9,7 @@ use std::task::*;
 /// Implemented futures::stream::Stream;
 pub struct AsyncStream<T>
 where
-    T: Unpin + Send + Sync + 'static,
+    T: Unpin + Send + 'static,
 {
     rx: AsyncRx<T>,
     waker: Option<LockedWaker>,
@@ -19,7 +19,7 @@ where
 
 impl<T> AsyncStream<T>
 where
-    T: Unpin + Send + Sync + 'static,
+    T: Unpin + Send + 'static,
 {
     pub fn new(rx: AsyncRx<T>) -> Self {
         Self { rx, waker: None, phan: Default::default(), ended: false }
@@ -28,7 +28,7 @@ where
 
 impl<T> stream::Stream for AsyncStream<T>
 where
-    T: Unpin + Send + Sync + 'static,
+    T: Unpin + Send + 'static,
 {
     type Item = T;
 
@@ -49,7 +49,7 @@ where
 
 impl<T> stream::FusedStream for AsyncStream<T>
 where
-    T: Unpin + Send + Sync + 'static,
+    T: Unpin + Send + 'static,
 {
     fn is_terminated(&self) -> bool {
         self.ended
@@ -58,7 +58,7 @@ where
 
 impl<T> Drop for AsyncStream<T>
 where
-    T: Unpin + Send + Sync + 'static,
+    T: Unpin + Send + 'static,
 {
     fn drop(&mut self) {
         if let Some(waker) = self.waker.take() {

--- a/src/waker_registry.rs
+++ b/src/waker_registry.rs
@@ -83,9 +83,9 @@ impl RegistryTrait for RegistrySingle {
             Err(_weak) => {
                 if let Some(old_waker) = self.queue.pop() {
                     _weak.check_eq(old_waker);
-                    self.queue.push(_weak).expect("Do not mis-use mpsc as mpmc");
+                    self.queue.push(_weak).expect("Do not misuse mpsc as mpmc");
                 } else {
-                    self.queue.push(_weak).expect("Do not mis-use mpsc as mpmc");
+                    self.queue.push(_weak).expect("Do not misuse mpsc as mpmc");
                 }
             }
         }


### PR DESCRIPTION
In the previous commit, I added code for safety cover for misuse, but  it's not enough. Those code might be removed in future versions that optimise for speed. 
```
commit 491eceb8aef7dd3c7a13afbecd14082fbaca0e09
Author: plan <frostyplanet@gmail.com>
Date:   Mon Jul 7 12:10:17 2025 +0800

    Protect against misuse of mpsc & spsc
    
    Unify duplicated code of send_wakers and recv_wakers (backport from dev)
```

Remove Sync marker in Tx, Rx, AsyncTx, AsyncRx

To prevent misuse with Arc in concurrent situation. Added doc test for compile_fail.
Change AsyncTx.send & AsyncRx.recv from `async fn` to `fn` that return Future