### PR TITLE
Add send_timeout & recv_timeout for async context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3"
 enum_dispatch = "0.3"
 async-trait = "0"
 parking_lot = "0"
+tokio = { version = "1", features = ["time"], optional=true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time", "sync", "rt-multi-thread", "rt", "macros"] }
@@ -34,6 +35,18 @@ criterion = { version="0.6", features = ["async_tokio", "csv_output"] }
 
 flume = {version="0.11", features= ["async"] }
 kanal = {version="0.1"}
+
+[features]
+default = []
+tokio = ["dep:tokio"]
+
+[package.metadata.docs.rs]
+all-features = true
+# enable features in the documentation
+rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.playground]
+features = ["tokio"]
 
 [[bench]]
 name = "crossfire"

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ init: git-hooks
 fmt: init
 	cargo fmt
 
+.PHONY: doc
+doc:
+	RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+
 .PHONY: test
 test: init
 	@echo "Run test"

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 RUNTESTCASE = _run_test_case() {                                                  \
     case="$(filter-out $@,$(MAKECMDGOALS))";                                      \
     if [ -n "$${case}" ]; then                                                    \
-        RUST_BACKTRACE=full cargo test $${case} -- --nocapture --test-threads=1;  \
+        RUST_BACKTRACE=full cargo test $${case} -F=tokio -- --nocapture --test-threads=1;  \
     else                                                                          \
-        RUST_BACKTRACE=full cargo test -- --nocapture --test-threads=1;           \
+        RUST_BACKTRACE=full cargo test -F=tokio -- --nocapture --test-threads=1;           \
     fi  \
 }
 
 RUNRELEASECASE = _run_test_release_case() {                                                  \
     case="$(filter-out $@,$(MAKECMDGOALS))";                                      \
     if [ -n "$${case}" ]; then                                                    \
-        RUST_BACKTRACE=full cargo test $${case} --release -- --nocapture --test-threads=1;  \
+        RUST_BACKTRACE=full cargo test $${case} -F=tokio --release -- --nocapture --test-threads=1;  \
     else                                                                          \
-        RUST_BACKTRACE=full cargo test --release -- --nocapture --test-threads=1;                                            \
+        RUST_BACKTRACE=full cargo test --release -F=tokio -- --nocapture --test-threads=1;                                            \
     fi  \
 }
 

--- a/README.md
+++ b/README.md
@@ -108,12 +108,19 @@ examples in type document).
 
 Error types are re-exported from crossbeam-channel:  [TrySendError], [SendError], [TryRecvError], [RecvError]
 
+### Feature flags
+
+- `tokio`: Enable send_timeout, recv_timeout API for async context, implement base on tokio
+
+
 ### Async compatibility
 
-Mainly tested on tokio-1.x.
+Mainly tested on tokio-1.x. But default we do not depend on any async runtime.
 
-In async context, future-select! can be used.  Cancelling is supported. You can combine
-send() or recv() future with tokio::time::timeout.
+In async context, tokio-select! or future-select! can be used.  Cancelling is supported. You can combine
+recv() future with tokio::time::timeout. When feature "tokio" enable, we also provide
+[send_timeout](crate::AsyncTx::send_timeout()) and
+[recv_timeout](crate::AsyncRx::recv_timeout())
 
 While using MAsyncTx or MAsyncRx, there's memory overhead to pass along small size wakers
 for pending async producer or consumer. Because we aim to be lockless,

--- a/src/async_rx.rs
+++ b/src/async_rx.rs
@@ -96,7 +96,7 @@ impl<T> AsyncRx<T> {
     ///
     /// Returns Err([RecvTimeoutError::Timeout]) when a message could not be received because the channel is empty and the operation timed out.
     ///
-    /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped.
+    /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped and channel is empty.
     #[cfg(feature = "tokio")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
     #[inline]
@@ -116,7 +116,7 @@ impl<T> AsyncRx<T> {
     ///
     /// Returns Err([TryRecvError::Empty]) when channel is empty.
     ///
-    /// Returns Err([TryRecvError::Disconnected]) when all Tx dropped.
+    /// Returns Err([TryRecvError::Disconnected]) when all Tx dropped and channel is empty.
     #[inline(always)]
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
         match self.recv.try_recv() {
@@ -152,7 +152,7 @@ impl<T> AsyncRx<T> {
     ///
     /// Return Err([TryRecvError::Empty]) for Poll::Pending case.
     ///
-    /// Return Err([TryRecvError::Disconnected]) when all Tx dropped.
+    /// Return Err([TryRecvError::Disconnected]) when all Tx dropped and channel is empty.
     #[inline(always)]
     pub fn poll_item(
         &self, ctx: &mut Context, o_waker: &mut Option<LockedWaker>,
@@ -350,7 +350,7 @@ pub trait AsyncRxTrait<T: Unpin + Send + 'static>: Send + 'static {
     ///
     /// Returns Err([RecvTimeoutError::Timeout]) when a message could not be received because the channel is empty and the operation timed out.
     ///
-    /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped.
+    /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped and channel is empty.
     #[cfg(feature = "tokio")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
     fn recv_timeout<'a>(&'a self, timeout: std::time::Duration) -> ReceiveTimeoutFuture<'a, T>;
@@ -361,7 +361,7 @@ pub trait AsyncRxTrait<T: Unpin + Send + 'static>: Send + 'static {
     ///
     /// Returns Err([TryRecvError::Empty]) when channel is empty.
     ///
-    /// Returns Err([TryRecvError::Disconnected]) when all Tx dropped.
+    /// Returns Err([TryRecvError::Disconnected]) when all Tx dropped and channel is empty.
     fn try_recv(&self) -> Result<T, TryRecvError>;
 
     /// Probe possible messages in the channel (not accurate)

--- a/src/blocking_rx.rs
+++ b/src/blocking_rx.rs
@@ -88,7 +88,7 @@ impl<T> Rx<T> {
     ///
     /// Returns Err([TryRecvError::Empty]) when channel is empty.
     ///
-    /// returns Err([TryRecvError::Disconnected]) when all Tx dropped.
+    /// returns Err([TryRecvError::Disconnected]) when all Tx dropped and channel is empty.
     #[inline]
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
         match self.recv.try_recv() {
@@ -110,7 +110,7 @@ impl<T> Rx<T> {
     ///
     /// Returns Err([RecvTimeoutError::Timeout]) when a message could not be received because the channel is empty and the operation timed out.
     ///
-    /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped.
+    /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped and channel is empty.
     #[inline]
     pub fn recv_timeout(&self, duration: Duration) -> Result<T, RecvTimeoutError> {
         match self.recv.recv_timeout(duration) {
@@ -197,7 +197,7 @@ pub trait BlockingRxTrait<T: Send + 'static>: Send + 'static {
     ///
     /// Returns Err([TryRecvError::Empty]) when channel is empty.
     ///
-    /// Returns Err([TryRecvError::Disconnected]) when all Tx dropped.
+    /// Returns Err([TryRecvError::Disconnected]) when all Tx dropped and channel is empty.
     fn try_recv(&self) -> Result<T, TryRecvError>;
 
     /// Waits for a message to be received from the channel, but only for a limited time.
@@ -207,7 +207,7 @@ pub trait BlockingRxTrait<T: Send + 'static>: Send + 'static {
     ///
     /// Returns Err([RecvTimeoutError::Timeout]) when a message could not be received because the channel is empty and the operation timed out.
     ///
-    /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped.
+    /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped and channel is empty.
     fn recv_timeout(&self, timeout: Duration) -> Result<T, RecvTimeoutError>;
 
     /// Probe possible messages in the channel (not accurate)

--- a/src/blocking_rx.rs
+++ b/src/blocking_rx.rs
@@ -103,14 +103,17 @@ impl<T> Rx<T> {
     /// Waits for a message to be received from the channel, but only for a limited time.
     /// Will block when channel is empty.
     ///
+    /// The behavior is atomic, either successfully polls a message,
+    /// or operation cancelled due to timeout.
+    ///
     /// Returns Ok(T) when successful.
     ///
     /// Returns Err([RecvTimeoutError::Timeout]) when a message could not be received because the channel is empty and the operation timed out.
     ///
     /// returns Err([RecvTimeoutError::Disconnected]) when all Tx dropped.
     #[inline]
-    pub fn recv_timeout(&self, timeout: Duration) -> Result<T, RecvTimeoutError> {
-        match self.recv.recv_timeout(timeout) {
+    pub fn recv_timeout(&self, duration: Duration) -> Result<T, RecvTimeoutError> {
+        match self.recv.recv_timeout(duration) {
             Err(e) => return Err(e),
             Ok(i) => {
                 self.shared.on_recv();

--- a/src/blocking_tx.rs
+++ b/src/blocking_tx.rs
@@ -102,11 +102,13 @@ impl<T> Tx<T> {
     }
 
     /// Waits for a message to be sent into the channel, but only for a limited time.
-    /// Will block when channel is empty.
+    /// Will block when channel is full.
+    ///
+    /// The behavior is atomic, either message sent successfully or returned on error.
     ///
     /// Returns `Ok(())` when successful.
     ///
-    /// Returns Err([SendTimeoutError::Timeout]) when the message could not be sent because the channel is full and the operation timed out.
+    /// Returns Err([SendTimeoutError::Timeout]) when the the operation timed out.
     ///
     /// Returns Err([SendTimeoutError::Disconnected]) when all Rx dropped.
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
+
 //! # Crossfire
 //!
 //! High-performance spsc/mpsc/mpmc channels.
@@ -87,14 +90,22 @@
 //!
 //! ### Error types
 //!
-//! Error types are re-exported from crossbeam-channel:  [TrySendError], [SendError], [TryRecvError], [RecvError],
+//! Error types are re-exported from crossbeam-channel:
+//!
+//! [TrySendError], [SendError], [SendTimeoutError], [TryRecvError], [RecvError], [RecvTimeoutError]
+//!
+//! ### Feature flags
+//!
+//! - `tokio`: Enable send_timeout, recv_timeout API for async context, implement base on tokio
 //!
 //! ### Async compatibility
 //!
-//! Mainly tested on tokio-1.x.
+//! Mainly tested on tokio-1.x. But default we do not depend on any async runtime.
 //!
-//! In async context, future-select! can be used.  Cancelling is supported. You can combine
-//! send() or recv() future with tokio::time::timeout.
+//! In async context, tokio-select! or future-select! can be used.  Cancelling is supported. You can combine
+//! recv() future with tokio::time::timeout. When feature "tokio" enable, we also provide
+//! [send_timeout](crate::AsyncTx::send_timeout()) and
+//! [recv_timeout](crate::AsyncRx::recv_timeout())
 //!
 //! While using MAsyncTx or MAsyncRx, there's memory overhead to pass along small size wakers
 //! for pending async producer or consumer. Because we aim to be lockless,


### PR DESCRIPTION
The return type is the same with blocking context (SendTimeoutError & RecvTimeoutError)

background:  https://github.com/frostyplanet/crossfire-rs/discussions/11

Add a randomized pressure test for timeout behavior, ensuring all messages are received.