### PR TITLE
Fix deadlock

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -95,16 +95,6 @@ impl ChannelShared {
         self.senders.fire()
     }
 
-    #[inline(always)]
-    pub(crate) fn cancel_recv_waker(&self, waker: LockedWaker) {
-        self.recvs.cancel_waker(waker);
-    }
-
-    #[inline(always)]
-    pub(crate) fn cancel_send_waker(&self, waker: LockedWaker) {
-        self.senders.cancel_waker(waker);
-    }
-
     /// On timeout, clear dead wakers on sender queue
     #[inline(always)]
     pub(crate) fn clear_send_wakers(&self, seq: u64) {

--- a/src/waker_registry.rs
+++ b/src/waker_registry.rs
@@ -96,7 +96,11 @@ impl RegistryTrait for RegistrySingle {
 
     #[inline(always)]
     fn fire(&self) {
-        self.cell.wake();
+        while let Some(waker) = self.cell.pop() {
+            if waker.wake() {
+                return;
+            }
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
https://github.com/frostyplanet/crossfire-rs/issues/22

Consider this situation:

thread1 try_send1 failed
thread1 reg_send_async (waker1)
thread1 try_send2  Ok, but weaker is still in registry. thread2 reg_send_async (waker3)
thread2 try_send2 failed (channel is full).
thread3 recv  Ok,   (channel is empty)
thread2 on_recv,  saw  weaker1. (waked=false)
thread2 weaker1.wake() and returned. waked=true.
thread1 cancel
no more receiver call try_recv.
thread3 will deadlock (because waker3 is not called)