### PR TITLE
mark `SendFuture` type as `#[must_use]` to ensure the compiler will w…

### DIFF
--- a/src/async_tx.rs
+++ b/src/async_tx.rs
@@ -317,6 +317,7 @@ impl<T: Unpin + Send + 'static> AsyncTx<T> {
 }
 
 /// A fixed-sized future object constructed by [AsyncTx::make_send_future()]
+#[must_use]
 pub struct SendFuture<'a, T: Unpin> {
     tx: &'a AsyncTx<T>,
     item: MaybeUninit<T>,


### PR DESCRIPTION
…arn users if a `send` call on a channel is not awaited.

This was causing us to silently not send values across a channel, so I believe its important to mark `SendFuture` as `#[must_use]` or at least annotate the `send` method with it to ensure the future is actually awaited when sending values over a channel

Thanks for the great crate otherwise :+1: 