### PR TITLE
Declare more specific log dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures-core = "0.3"
 parking_lot = "0"
 tokio = { version = "1", features = ["time", "rt"], optional=true }
 async-std = {version = "1", optional=true}
-log = { version="0", optional=true}
+log = { version="0.4", optional=true}
 smallvec = "1"
 pointers = "0"
 


### PR DESCRIPTION
Crossfire does not work with any other version of the log crate.

With log 0.3 it fails like this:

```console
error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/shared.rs:165:13
    |
165 |             trace_log!("closing from tx");
    |             ----------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/shared.rs:169:13
    |
169 |             trace_log!("drop tx {}", old - 1);
    |             --------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/shared.rs:178:13
    |
178 |             trace_log!("closing from rx");
    |             ----------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/shared.rs:183:13
    |
183 |             trace_log!("drop rx {}", old - 1);
    |             --------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/shared.rs:258:17
    |
258 |                 trace_log!("tx: abandon err  {:?} {}", waker, state);
    |                 ---------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/shared.rs:277:13
    |
277 |             trace_log!("rx: abandon err {:?} {}", waker, state);
    |             --------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:160:13
    |
160 |             trace_log!("{} wake", self._tag);
    |             -------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:169:9
    |
169 |         trace_log!("{}{:?}: reg {:?}", self._tag, tokio_task_id!(), waker);
    |         ------------------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:180:9
    |
180 |         trace_log!("{}{:?}: reg {:?}", self._tag, tokio_task_id!(), waker);
    |         ------------------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:254:9
    |
254 |         trace_log!("{}: reg for select", self._tag);
    |         ------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |               log::debug!($($arg)+);
    |               ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:334:29
    |
334 | / ...                   trace_log!(
335 | | ...                       "{} {:?}: will_wake {:?}",
336 | | ...                       self._tag,
337 | | ...                       tokio_task_id!(),
338 | | ...                       waker
339 | | ...                   );
    | |_______________________- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |               log::debug!($($arg)+);
    |               ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:349:29
    |
349 | / ...                   trace_log!(
350 | | ...                       "{} {:?}: drop waker {:?}",
351 | | ...                       self._tag,
352 | | ...                       tokio_task_id!(),
353 | | ...                       waker
354 | | ...                   );
    | |_______________________- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:375:13
    |
375 |             trace_log!("{}{:?}: re-reg {:?}", self._tag, tokio_task_id!(), waker);
    |             --------------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:380:13
    |
380 |             trace_log!("{}{:?}: reg {:?}", self._tag, tokio_task_id!(), waker);
    |             ------------------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:505:16
    |
505 |             if process!(guard, weak) {
    |                --------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `process` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:513:24
    |
513 |                     if process!(guard, _weak) {
    |                        ---------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `process` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:566:17
    |
566 |                 trace_log!("close {} wake {:?} {}", self._tag, waker, _r);
    |                 --------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:594:17
    |
594 |                 trace_log!("{}: abandon cancel {:?}", self._tag, waker);
    |                 ------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:618:13
    |
618 |             trace_log!("wake {} {:?} {:?}", self._tag, waker, r);
    |             ---------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:627:21
    |
627 |                     trace_log!("wake {} {:?} {:?}", self._tag, _waker, r);
    |                     ----------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:635:25
    |
635 |                         trace_log!("wake {} stop at {}", self._tag, last_seq);
    |                         ----------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:685:17
    |
685 |                 trace_log!("{}: cancel_reuse {:?} {}", self._tag, waker, cur_state);
    |                 ------------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:727:9
    |
727 |         trace_log!("{}: reg for select", self._tag);
    |         ------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/waker_registry.rs:756:13
    |
756 |             trace_log!("rx: wake select");
    |             ----------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |               log::debug!($($arg)+);
    |               ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:120:17
    |
120 | /                 trace_log!(
121 | |                     "oneshot:({:?}) recv value={} & destroy",
122 | |                     tokio_task_id!(),
123 | |                     item.is_some()
124 | |                 );
    | |_________________- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |               log::debug!($($arg)+);
    |               ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:132:17
    |
132 | /                 trace_log!(
133 | |                     "oneshot:({:?}) recv value={} {state} close retry",
134 | |                     tokio_task_id!(),
135 | |                     item.is_some()
136 | |                 );
    | |_________________- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |               log::debug!($($arg)+);
    |               ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:139:17
    |
139 | /                 trace_log!(
140 | |                     "oneshot:({:?}) recv value={} {state}",
141 | |                     tokio_task_id!(),
142 | |                     item.is_some()
143 | |                 );
    | |_________________- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:163:17
    |
163 |                 trace_log!("oneshot:({:?}) rx closed", tokio_task_id!());
    |                 -------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:171:25
    |
171 |                         trace_log!("oneshot:({:?}) send value", tokio_task_id!());
    |                         --------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:177:29
    |
177 | ...                   trace_log!("oneshot:({:?}) wake rx", tokio_task_id!());
    |                       ------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:192:29
    |
192 | ...                   trace_log!("oneshot:({:?}) rx closed {state}", tokio_task_id!());
    |                       ---------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:289:17
    |
289 |                 trace_log!("oneshot:({:?}) rx drop destroy, state={}", tokio_task_id!(), old_state);
    |                 ----------------------------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:299:17
    |
299 |                 trace_log!("oneshot:({:?}) rx drop, state={}", tokio_task_id!(), old_state);
    |                 --------------------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:401:17
    |
401 |                 trace_log!("oneshot:({:?}) spurious waked state {}", tokio_task_id!(), state,);
    |                 ------------------------------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:444:9
    |
444 |         try_recv!(Acquire);
    |         ------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `try_recv` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:447:13
    |
447 |             try_recv!(Acquire);
    |             ------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `try_recv` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:452:9
    |
452 |         trace_log!("oneshot: waker set");
    |         -------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:454:13
    |
454 |             try_recv!(SeqCst);
    |             ----------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `try_recv` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/oneshot.rs:463:21
    |
463 |                     trace_log!("oneshot: to cancel_waker on timeout");
    |                     ------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1008:17
     |
1008 |                 trace_log!("wg:({:?}) drop delay state={}", tokio_task_id!(), state - 1);
     |                 ------------------------------------------------------------------------ in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1012:17
     |
1012 |                 trace_log!("wg:({:?}) drop", tokio_task_id!());
     |                 ---------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1033:9
     |
1033 |         trace_log!("wg:({:?}) enter done {count} {threshold}", tokio_task_id!());
     |         ------------------------------------------------------------------------ in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1042:25
     |
1042 |                         trace_log!("wg:({:?}) done drop {count} {threshold}", tokio_task_id!());
     |                         ----------------------------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |               log::debug!($($arg)+);
     |               ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1063:37
     |
1063 | / ...                   trace_log!(
1064 | | ...                       "wg:({:?}) done locked drop cur {count} = 0",
1065 | | ...                       tokio_task_id!(),
1066 | | ...                   );
     | |_______________________- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |               log::debug!($($arg)+);
     |               ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1075:33
     |
1075 | / ...                   trace_log!(
1076 | | ...                       "wg:({:?}) done waked {count} -> {} <= {threshold}",
1077 | | ...                       tokio_task_id!(),
1078 | | ...                       s.count()
1079 | | ...                   );
     | |_______________________- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1083:29
     |
1083 | ...                   trace_log!("wg:({:?}) done {count} -> {}", tokio_task_id!(), s.count());
     |                       ----------------------------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1108:17
     |
1108 |                 trace_log!("wg:({:?}) set_waker try again", tokio_task_id!());
     |                 ------------------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1113:21
     |
1113 |                     trace_log!("wg:({:?}) set_waker skip", tokio_task_id!());
     |                     -------------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1124:17
     |
1124 |                 trace_log!("wg:({:?}) set_waker replaced", tokio_task_id!());
     |                 ------------------------------------------------------------ in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1129:17
     |
1129 |                 trace_log!("wg:({:?}) set_waker ok", tokio_task_id!());
     |                 ------------------------------------------------------ in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1151:9
     |
1151 |         check!(Acquire);
     |         --------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1156:13
     |
1156 |             check!(Acquire);
     |             --------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1192:25
     |
1192 |         let has_waker = check!(Acquire);
     |                         --------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1198:21
     |
1198 |                     trace_log!("wg:({:?}) will_wake=true", tokio_task_id!());
     |                     -------------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1199:21
     |
1199 |                     check!(SeqCst);
     |                     -------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1200:21
     |
1200 |                     trace_log!("wg:({:?}) PENDING", tokio_task_id!());
     |                     ------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1203:21
     |
1203 |                     trace_log!("wg:({:?}) waker will_wake=false", tokio_task_id!())
     |                     --------------------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1208:13
     |
1208 |             trace_log!("wg:({:?}) READY during set_waker", tokio_task_id!());
     |             ---------------------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/lib.rs:311:13
     |
 311 |             log::debug!($($arg)+);
     |             ^^^^^^^^^^^^^^^^^^^^^
     |
    ::: src/waitgroup.rs:1212:13
     |
1212 |             trace_log!("wg:({:?}) PENDING", tokio_task_id!());
     |             ------------------------------------------------- in this macro invocation
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_tx.rs:121:13
    |
121 |             trace_log!("tx: send");
    |             ---------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_tx.rs:143:13
    |
143 |             trace_log!("tx: sender_double_check {:?} state={}", o_waker, state);
    |             ------------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_tx.rs:169:21
    |
169 |                     trace_log!("tx: after park state={}", state);
    |                     -------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_tx.rs:177:25
    |
177 |                         return_ok!();
    |                         ------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `return_ok` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_tx.rs:185:17
    |
185 |                 return_ok!();
    |                 ------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `return_ok` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_rx.rs:111:21
    |
111 |         try_recv!({ on_recv_no_waker!() });
    |                     ------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_no_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_rx.rs:119:25
    |
119 |             try_recv!({ on_recv_no_waker!() });
    |                         ------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_no_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_rx.rs:131:17
    |
131 |                 trace_log!("rx: recv cancel {:?} Init", o_waker);
    |                 ------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_rx.rs:136:13
    |
136 |             trace_log!("rx: {:?} commit_waiting state={}", o_waker, state);
    |             -------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_rx.rs:154:17
    |
154 |                 trace_log!("rx: after park state={}", state);
    |                 -------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_rx.rs:161:29
    |
161 |                 try_recv!({ on_recv_waker!() });
    |                             ---------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/blocking_rx.rs:167:21
    |
167 |         try_recv!({ on_recv_waker!() });
    |                     ---------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_tx.rs:254:13
    |
254 |             trace_log!("tx{:?}: closed {:?}", tokio_task_id!(), o_waker);
    |             ------------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_tx.rs:264:21
    |
264 |                     trace_log!("tx{:?}: send {:?}", tokio_task_id!(), _waker);
    |                     --------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_tx.rs:266:21
    |
266 |                     trace_log!("tx{:?}: send", tokio_task_id!());
    |                     -------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_tx.rs:276:29
    |
276 | ...                   trace_log!("tx{:?}: send", tokio_task_id!());
    |                       -------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_tx.rs:291:13
    |
291 |             trace_log!("tx{:?}: sender_double_check {:?} {}", tokio_task_id!(), o_waker, state);
    |             ----------------------------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_tx.rs:296:21
    |
296 |                     trace_log!("tx{:?}: send {:?} done", o_waker, tokio_task_id!());
    |                     --------------------------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_tx.rs:301:21
    |
301 |                     trace_log!("tx{:?}: closed {:?}", o_waker, tokio_task_id!());
    |                     ------------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_rx.rs:280:39
    |
280 |                 try_recv!(try_recv=>{ on_recv_no_waker!()});
    |                                       ------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_no_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_rx.rs:285:47
    |
285 |                         try_recv!(try_recv=>{ on_recv_no_waker!()});
    |                                               ------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_no_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_rx.rs:292:40
    |
292 |                 try_recv!(try_recv => {on_recv_waker!(WakerState::Woken)});
    |                                        --------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_rx.rs:301:42
    |
301 |             try_recv!(try_recv_final =>{ on_recv_waker!(WakerState::Init)});
    |                                          -------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_rx.rs:304:17
    |
304 |                 trace_log!("rx{:?}: commit_waiting {:?} {}", tokio_task_id!(), o_waker, state);
    |                 ------------------------------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_rx.rs:312:36
    |
312 |             try_recv!(try_recv =>{ on_recv_waker!(WakerState::Closed)});
    |                                    ---------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `on_recv_waker` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/async_rx.rs:313:13
    |
313 |             trace_log!("rx{:?}: disconnected {:?}", tokio_task_id!(), o_waker);
    |             ------------------------------------------------------------------ in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/select/select.rs:222:17
    |
222 |                 trace_log!("select ok idx={}", idx);
    |                 ----------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/select/select.rs:228:17
    |
228 |                 trace_log!("select: final_check {}", idx);
    |                 ----------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/select/select.rs:327:13
    |
327 |             trace_log!("select: park");
    |             -------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/select/select.rs:342:17
    |
342 |                 trace_log!("select: unpark state={}", state);
    |                 -------------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/select/select.rs:347:13
    |
347 |             trace_log!("select: hint idx {}", idx);
    |             -------------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:311:13
    |
311 |             log::debug!($($arg)+);
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/select/select.rs:390:13
    |
390 |             trace_log!("select: reg waker");
    |             ------------------------------- in this macro invocation
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `log::debug` which comes from the expansion of the macro `trace_log` (in Nightly builds, run with -Z macro-backtrace for more info)
```